### PR TITLE
add 5.0 load command example

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -8,6 +8,8 @@
 :data: false
 :use-load-script: false
 :use-dump-file: data/pole-40.dump
+:use-dump-path: data
+:use-dump-file-v5: pole-50
 :zip-file: data/pole.zip
 :use-plugin: graph-algorithms
 :target-db-version: 3.5,4.0
@@ -78,9 +80,18 @@ ifeval::[{use-dump-file} != false]
 
 * Use the neo4j-admin tool to load data from the command line with the command below.
 
+Neo4j 4.x and below
+
 [source,shell,subs=attributes]
 ----
 bin/neo4j-admin load --from {use-dump-file} [--database "database"]
+----
+
+Neo4j 5.x
+
+[source,shell,subs=attributes]
+----
+bin/neo4j-admin database load --from-path={use-dump-path} {use-dump-file-v5} 
 ----
 
 * Upload the dump file to Neo4j Aura via https://console.neo4j.io/#import-instructions


### PR DESCRIPTION
We had a support case around loading the example pole data into Neo4j 5.5. The usage of the load command in README.adoc does not contain an example of how to use `neo4j-admin` load in Neo4j 5, which caused some confusion. 

The [neo4j-admin load](https://neo4j.com/docs/operations-manual/current/backup-restore/restore-dump/) command has changed in Neo4j 5. 

This PR separates Neo4j 4 and Neo4j 5 `neo4j-admin` load commands. 

